### PR TITLE
Api からのデータ取得周り

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vscode/launch.json
+.env

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,8 +52,7 @@ function AppProvider(props: { children: React.ReactNode }) {
           const _prefectures_list_data = result.result.map((value:PrefecturesAPIData)=>{
             return ({
               ...value,
-              //要修正　falseへ
-              checked:true
+              checked:false
             })
           })
           setPrefecturesListData(_prefectures_list_data)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,67 @@
-import React, { useEffect, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import './App.scss';
 import Layout from './Layout/Layout';
 import PopulationChart from './population_chart/PopulationChart';
 import PrefecturesList from './prefectures_list/PrefecturesList';
+import { PrefecturesAPIData, PrefecturesData } from './types';
 
 
 const API_URL_PREFECTURES = "https://opendata.resas-portal.go.jp/api/v1/prefectures"
 const API_KEY = process.env.REACT_APP_API_KEY || ""
 
 
-function App() {
-  const [prefectures_list_data, setPrefecturesListData] = useState()
-  
-  useEffect(()=>{
+export const PrefecturesListDataContext = createContext(
+  {} as {
+    prefectures_list_data: Array<PrefecturesData>,
+    setPrefecturesListData: React.Dispatch<React.SetStateAction<PrefecturesData[]>>
+  }
+)
+
+//APIからデータを受け取り、useContextを使って子供コンポーネントに受け渡すProvider
+function AppProvider(props: { children: React.ReactNode }) {
+  const [prefectures_list_data, setPrefecturesListData] = useState<Array<PrefecturesData>>([])
+
+  useEffect(() => {
     fetch(
       API_URL_PREFECTURES,
       {
-        method:"GET",
-        headers:{
-          "X-API-KEY":API_KEY,
+        method: "GET",
+        headers: {
+          "X-API-KEY": API_KEY,
         }
       }
     )
-    .then(res=>res.json())
-    .then(
-      (result)=>{
-        setPrefecturesListData(result.result)
-        console.log(result)
-      },
-      (error)=>{
-        console.log(error)
-      }
-    )
-  },[])
+      .then(res => res.json())
+      .then(
+        (result) => {
+          const _prefectures_list_data = result.result.map((item: PrefecturesAPIData) => {
+            return { checked: false, ...item }
+          })
+          setPrefecturesListData(_prefectures_list_data)
+        },
+        (error) => {
+          console.log(error)
+        }
+      )
+  }, [])
+
 
   return (
+    <PrefecturesListDataContext.Provider value={{ prefectures_list_data, setPrefecturesListData }}>
+      {props.children}
+    </PrefecturesListDataContext.Provider>
+  )
+}
+
+function App() {
+  return (
     <Layout>
-      <div className="container">
-        <PrefecturesList />
-        <PopulationChart />
-      </div>
+      <AppProvider>
+        <div className="container">
+          <PrefecturesList />
+          <PopulationChart />
+        </div>
+      </AppProvider>
     </Layout>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,24 +3,39 @@ import './App.scss';
 import Layout from './Layout/Layout';
 import PopulationChart from './population_chart/PopulationChart';
 import PrefecturesList from './prefectures_list/PrefecturesList';
-import { PrefecturesAPIData, PrefecturesData } from './types';
+import { PrefectureData } from './types';
 
 
 const API_URL_PREFECTURES = "https://opendata.resas-portal.go.jp/api/v1/prefectures"
 const API_KEY = process.env.REACT_APP_API_KEY || ""
 
-
+//Prefectures List Data
 export const PrefecturesListDataContext = createContext(
   {} as {
-    prefectures_list_data: Array<PrefecturesData>,
-    setPrefecturesListData: React.Dispatch<React.SetStateAction<PrefecturesData[]>>
+    prefectures_list_data: Array<PrefectureData>,
+    setPrefecturesListData: React.Dispatch<React.SetStateAction<PrefectureData[]>>
   }
 )
 
-//APIからデータを受け取り、useContextを使って子供コンポーネントに受け渡すProvider
-function AppProvider(props: { children: React.ReactNode }) {
-  const [prefectures_list_data, setPrefecturesListData] = useState<Array<PrefecturesData>>([])
+//都道府県リストのチェックボックスの変更を受け取る(prefName)
+export const CheckboxCheckerContext = createContext(
+  {} as {
+    checkbox_checker: PrefectureData,
+    setCheckboxChecker: React.Dispatch<React.SetStateAction<PrefectureData>>
+  }
+)
 
+
+//Provider : 都道府県リスト、チェックボックスの変更データ
+function AppProvider(props: { children: React.ReactNode }) {
+  const [prefectures_list_data, setPrefecturesListData] = useState<Array<PrefectureData>>([])
+  const [checkbox_checker, setCheckboxChecker] = useState<PrefectureData>({
+    prefCode: 1,
+    prefName: "北海道",
+    checked: false,
+  })
+
+  //都道府県リストのデータをAPIから受け取る
   useEffect(() => {
     fetch(
       API_URL_PREFECTURES,
@@ -34,9 +49,7 @@ function AppProvider(props: { children: React.ReactNode }) {
       .then(res => res.json())
       .then(
         (result) => {
-          const _prefectures_list_data = result.result.map((item: PrefecturesAPIData) => {
-            return { checked: false, ...item }
-          })
+          const _prefectures_list_data = result.result
           setPrefecturesListData(_prefectures_list_data)
         },
         (error) => {
@@ -48,7 +61,9 @@ function AppProvider(props: { children: React.ReactNode }) {
 
   return (
     <PrefecturesListDataContext.Provider value={{ prefectures_list_data, setPrefecturesListData }}>
-      {props.children}
+      <CheckboxCheckerContext.Provider value={{ checkbox_checker, setCheckboxChecker }}>
+        {props.children}
+      </CheckboxCheckerContext.Provider>
     </PrefecturesListDataContext.Provider>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './App.scss';
 import Layout from './Layout/Layout';
 import PopulationChart from './population_chart/PopulationChart';
 import PrefecturesList from './prefectures_list/PrefecturesList';
 
+
+const API_URL_PREFECTURES = "https://opendata.resas-portal.go.jp/api/v1/prefectures"
+const API_KEY = process.env.REACT_APP_API_KEY || ""
+
+
 function App() {
+  const [prefectures_list_data, setPrefecturesListData] = useState()
+  
+  useEffect(()=>{
+    fetch(
+      API_URL_PREFECTURES,
+      {
+        method:"GET",
+        headers:{
+          "X-API-KEY":API_KEY,
+        }
+      }
+    )
+    .then(res=>res.json())
+    .then(
+      (result)=>{
+        setPrefecturesListData(result.result)
+        console.log(result)
+      },
+      (error)=>{
+        console.log(error)
+      }
+    )
+  },[])
+
   return (
     <Layout>
       <div className="container">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import './App.scss';
 import Layout from './Layout/Layout';
 import PopulationChart from './population_chart/PopulationChart';
 import PrefecturesList from './prefectures_list/PrefecturesList';
-import { PrefectureData } from './types';
+import { PrefectureData, PrefecturesAPIData } from './types';
 
 
 const API_URL_PREFECTURES = "https://opendata.resas-portal.go.jp/api/v1/prefectures"
@@ -49,7 +49,13 @@ function AppProvider(props: { children: React.ReactNode }) {
       .then(res => res.json())
       .then(
         (result) => {
-          const _prefectures_list_data = result.result
+          const _prefectures_list_data = result.result.map((value:PrefecturesAPIData)=>{
+            return ({
+              ...value,
+              //要修正　falseへ
+              checked:true
+            })
+          })
           setPrefecturesListData(_prefectures_list_data)
         },
         (error) => {

--- a/src/Layout/Layout.scss
+++ b/src/Layout/Layout.scss
@@ -27,7 +27,7 @@ $breakpoints: (
 
 .children-container {
     margin: 10px;
-    background-color: rgba(138, 138, 138, 0.233);
+    background-color: antiquewhite;
     @include media(md) {
         margin: 10px 20px;
     }

--- a/src/Layout/Layout.tsx
+++ b/src/Layout/Layout.tsx
@@ -1,19 +1,14 @@
 import React, { ReactNode } from 'react';
 import './Layout.scss';
 
-type Props = {
-  children: ReactNode,
-}
-
-
-function Layout({ children }: Props) {
+function Layout(props:{ children:ReactNode }) {
   return (
     <div className="layout-container">
       <header>
         <h1>都道府県別　人口チャート</h1>
       </header>
       <div className="children-container">
-        {children}
+        {props.children}
       </div>
     </div>
   );

--- a/src/population_chart/PopulationChart.scss
+++ b/src/population_chart/PopulationChart.scss
@@ -22,5 +22,7 @@ $breakpoints: (
 .population-chart-container {
     width: 100%;
     height: 90vh;
-    padding: 5px;
+    padding: 4px;
+    background-color: whitesmoke;
+    border-radius: 8px;
 }

--- a/src/population_chart/PopulationChart.tsx
+++ b/src/population_chart/PopulationChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   LineChart,
   Line,
@@ -9,6 +9,8 @@ import {
   Legend,
   ResponsiveContainer
 } from "recharts";
+import { CheckboxCheckerContext, PrefecturesListDataContext } from '../App';
+import { PopulationChartData, PrefectureData, PrefecturesPopulationData } from '../types';
 
 import './PopulationChart.scss';
 
@@ -59,17 +61,129 @@ const data = [
   }
 ]
 
+const API_URL_POPULATION = "https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear"
+const API_KEY = process.env.REACT_APP_API_KEY || ""
+
+
+
+function CreateChartData(
+  prefectures_list_data: PrefectureData[],
+  population_data: PrefecturesPopulationData
+) {
+  var pre_data: PopulationChartData = {
+    0: { '': 0 },
+  }
+  var return_Line_list: any = []
+
+  prefectures_list_data.map((prefecture_value) => {
+    if (prefecture_value.checked) {
+      //Line のリスト生成　strokeの色を変えないと、同じ色のものが生成される　要変更
+      return_Line_list.push(
+        <Line
+          type="monotone"
+          dataKey={prefecture_value.prefName}
+          stroke="#82ca9d"
+          key={prefecture_value.prefCode}
+        />
+      )
+
+      //Chartの描写につかうデータを生成
+      if (prefecture_value.prefName in population_data) {
+        population_data[prefecture_value.prefName].map((population_value) => {
+          if (population_value.year in pre_data) {
+            pre_data[population_value.year] = {
+              ...pre_data[population_value.year],
+              [prefecture_value.prefName]: population_value.value
+            }
+          } else {
+            pre_data = {
+              ...pre_data,
+              [population_value.year]: {
+                [prefecture_value.prefName]: population_value.value,
+              }
+            }
+          }
+        })
+      }
+    }
+  })
+
+  const chart_data: any = []
+  Object.entries(pre_data).forEach(([key, value]) => {
+    if (key != "0") {
+      chart_data.push({
+        "year": key,
+        ...value
+      })
+    }
+  })
+
+  return [return_Line_list, chart_data]
+}
+
+
+
 
 
 
 //適当なデータを挿入して、チャートを表示させている　後で変更
 function PopulationChart() {
+  const { prefectures_list_data, setPrefecturesListData } = useContext(
+    PrefecturesListDataContext
+  )
+  const { checkbox_checker } = useContext(
+    CheckboxCheckerContext
+  )
+  const [population_data, setPopulationData] = useState<PrefecturesPopulationData>({})
+  const [Line_list, setLineList] = useState([])
+  const [chart_data, setChartData] = useState([])
+
+
+  useEffect(() => {
+    var _population_data = population_data
+    if ((checkbox_checker.checked) && ((checkbox_checker.prefName in population_data) == false)) {
+      fetch(
+        API_URL_POPULATION + encodeURI(`?prefCode=${checkbox_checker.prefCode}&cityCode=-`),
+        {
+          method: "GET",
+          headers: {
+            "X-API-KEY": API_KEY,
+          }
+        }
+      )
+        .then(res => res.json())
+        .then(
+          (result) => {
+            _population_data = {
+              ..._population_data,
+              [checkbox_checker.prefName]: result.result.data[0].data
+            }
+            //prefCodeの総人口をpopulation_dataに保存
+            setPopulationData(_population_data)
+          },
+          (error) => {
+            console.log(error)
+          }
+        )
+    }
+
+  }, [checkbox_checker])
+
+
+  useEffect(()=>{
+    const [Line_list, chart_data] = CreateChartData(prefectures_list_data, population_data)
+    
+    setLineList(Line_list)
+    setChartData(chart_data)
+  },[population_data])
+
+
   return (
     <section className="population-chart-container">
       <p>人口チャート</p>
       <ResponsiveContainer>
         <LineChart
-          data={data}
+          data={chart_data}
           margin={{
             top: 5,
             right: 30,
@@ -82,13 +196,7 @@ function PopulationChart() {
           <YAxis />
           <Tooltip />
           <Legend />
-          <Line
-            type="monotone"
-            dataKey="uv"
-            stroke="#8884d8"
-          />
-          <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
-          <Line type="monotone" dataKey="amt" stroke="#82ca9d" />
+          {Line_list}
         </LineChart>
       </ResponsiveContainer>
     </section>

--- a/src/population_chart/PopulationChart.tsx
+++ b/src/population_chart/PopulationChart.tsx
@@ -15,52 +15,6 @@ import { PopulationChartData, PrefectureData, PrefecturesPopulationData } from '
 import './PopulationChart.scss';
 
 
-//適当なデータを生成して出力させてみる 後で変更
-const data = [
-  {
-    "name": "Page A",
-    "uv": 4000,
-    "pv": 2400,
-    "amt": 2400
-  },
-  {
-    "name": "Page B",
-    "uv": 3000,
-    "pv": 1398,
-    "amt": 2210
-  },
-  {
-    "name": "Page C",
-    "uv": 2000,
-    "pv": 9800,
-    "amt": 2290
-  },
-  {
-    "name": "Page D",
-    "uv": 2780,
-    "pv": 3908,
-    "amt": 2000
-  },
-  {
-    "name": "Page E",
-    "uv": 1890,
-    "pv": 4800,
-    "amt": 2181
-  },
-  {
-    "name": "Page F",
-    "uv": 2390,
-    "pv": 3800,
-    "amt": 2500
-  },
-  {
-    "name": "Page G",
-    "uv": 3490,
-    "pv": 4300,
-    "amt": 2100
-  }
-]
-
 const API_URL_POPULATION = "https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear"
 const API_KEY = process.env.REACT_APP_API_KEY || ""
 
@@ -83,6 +37,7 @@ function CreateChartData(
           type="monotone"
           dataKey={prefecture_value.prefName}
           stroke="#82ca9d"
+          strokeWidth={4}
           key={prefecture_value.prefCode}
         />
       )
@@ -175,7 +130,7 @@ function PopulationChart() {
     
     setLineList(Line_list)
     setChartData(chart_data)
-  },[population_data])
+  },[checkbox_checker, population_data])
 
 
   return (
@@ -192,7 +147,7 @@ function PopulationChart() {
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="name" />
+          <XAxis dataKey="year" />
           <YAxis />
           <Tooltip />
           <Legend />

--- a/src/population_chart/PopulationChart.tsx
+++ b/src/population_chart/PopulationChart.tsx
@@ -7,7 +7,7 @@ import {
   CartesianGrid,
   Tooltip,
   Legend,
-  ResponsiveContainer
+  ResponsiveContainer,
 } from "recharts";
 import { CheckboxCheckerContext, PrefecturesListDataContext } from '../App';
 import { PopulationChartData, PrefectureData, PrefecturesPopulationData } from '../types';
@@ -17,7 +17,27 @@ import './PopulationChart.scss';
 
 const API_URL_POPULATION = "https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear"
 const API_KEY = process.env.REACT_APP_API_KEY || ""
-
+const COLOR_LIST = [
+  '#FFE4E1', '#708090', '#778899', '#696969', '#000099',
+  '#000066', '#87CEFA', '#B0C4DE', '#00008B', '#191970',
+  '#483D8B', '#4B0082', '#0000CD', '#7B68EE', '#4169E1',
+  '#6495ED', '#008BBB', '#4682B4', '#1E90FF', '#00BFFF',
+  '#22FFFF', '#002200', '#ADD8E6', '#00FFFF', '#5F9EA0',
+  '#20B2AA', '#66CDAA', '#00CED1', '#48D1CC', '#550000',
+  '#B0E0E6', '#AFEEEE', '#6B8E23', '#556B2F', '#006400',
+  '#228B22', '#2E8B57', '#3CB371', '#32CD32', '#9ACD32',
+  '#7FFFD4', '#00FA9A', '#00FF7F', '#7CFC00', '#7FFF00',
+  '#ADFF2F', '#90EE90', '#98FB98', '#8B008B', '#6A5ACD',
+  '#8A2BE2', '#9400D3', '#9932CC', '#BA55D3', '#9370DB',
+  '#8FBC8F', '#8B0000', '#8B4513', '#A52A2A', '#B22222',
+  '#A0522D', '#CD5C5C', '#D2691E', '#BDB76B', '#DC143C',
+  '#FF1493', '#FF69B4', '#FF00FF', '#DA70D6', '#EE82EE',
+  '#DDA0DD', '#D8BfD8', '#BC8F8F', '#C71585', '#DB7093',
+  '#E9967A', '#F08080', '#FFA07A', '#FFB6C1', '#FFC0CB',
+  '#FF4500', '#FF6347', '#FF4F50', '#FA8072', '#FF8C00',
+  '#FFA500', '#F4A460', '#E6E6FA', '#B8860B', '#CD853F',
+  '#DAA520', '#D2B48C', '#DEB887', '#FFD700',
+]
 
 
 function CreateChartData(
@@ -29,14 +49,14 @@ function CreateChartData(
   }
   var return_Line_list: any = []
 
-  prefectures_list_data.map((prefecture_value) => {
+  Object.entries(prefectures_list_data).forEach(([key, prefecture_value]) => {
     if (prefecture_value.checked) {
       //Line のリスト生成　strokeの色を変えないと、同じ色のものが生成される　要変更
       return_Line_list.push(
         <Line
           type="monotone"
           dataKey={prefecture_value.prefName}
-          stroke="#82ca9d"
+          stroke={COLOR_LIST[prefecture_value.prefCode]}
           strokeWidth={4}
           key={prefecture_value.prefCode}
         />
@@ -44,7 +64,7 @@ function CreateChartData(
 
       //Chartの描写につかうデータを生成
       if (prefecture_value.prefName in population_data) {
-        population_data[prefecture_value.prefName].map((population_value) => {
+        Object.entries(population_data[prefecture_value.prefName]).forEach(([key, population_value]) => {
           if (population_value.year in pre_data) {
             pre_data[population_value.year] = {
               ...pre_data[population_value.year],
@@ -65,7 +85,7 @@ function CreateChartData(
 
   const chart_data: any = []
   Object.entries(pre_data).forEach(([key, value]) => {
-    if (key != "0") {
+    if (key !== "0") {
       chart_data.push({
         "year": key,
         ...value
@@ -80,10 +100,8 @@ function CreateChartData(
 
 
 
-
-//適当なデータを挿入して、チャートを表示させている　後で変更
 function PopulationChart() {
-  const { prefectures_list_data, setPrefecturesListData } = useContext(
+  const { prefectures_list_data } = useContext(
     PrefecturesListDataContext
   )
   const { checkbox_checker } = useContext(
@@ -96,7 +114,7 @@ function PopulationChart() {
 
   useEffect(() => {
     var _population_data = population_data
-    if ((checkbox_checker.checked) && ((checkbox_checker.prefName in population_data) == false)) {
+    if ((checkbox_checker.checked) && ((checkbox_checker.prefName in population_data) === false)) {
       fetch(
         API_URL_POPULATION + encodeURI(`?prefCode=${checkbox_checker.prefCode}&cityCode=-`),
         {
@@ -125,12 +143,12 @@ function PopulationChart() {
   }, [checkbox_checker])
 
 
-  useEffect(()=>{
+  useEffect(() => {
     const [Line_list, chart_data] = CreateChartData(prefectures_list_data, population_data)
-    
+
     setLineList(Line_list)
     setChartData(chart_data)
-  },[checkbox_checker, population_data])
+  }, [checkbox_checker, population_data])
 
 
   return (
@@ -140,16 +158,28 @@ function PopulationChart() {
         <LineChart
           data={chart_data}
           margin={{
-            top: 5,
-            right: 30,
+            top: 30,
+            right: 60,
             left: 20,
             bottom: 40
           }}
+
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="year" />
-          <YAxis />
-          <Tooltip />
+          <XAxis
+            dataKey="year"
+            label={{
+              value: '年度', position: "right", offset: 20
+            }}
+          />
+          <YAxis
+            label={{
+              value: '人口数', position: 'top', offset: 10
+            }}
+          />
+          <Tooltip
+            viewBox={{ x: 400, y: 0, width: 400, height: 400 }}
+          />
           <Legend />
           {Line_list}
         </LineChart>

--- a/src/population_chart/PopulationChart.tsx
+++ b/src/population_chart/PopulationChart.tsx
@@ -19,24 +19,17 @@ const API_URL_POPULATION = "https://opendata.resas-portal.go.jp/api/v1/populatio
 const API_KEY = process.env.REACT_APP_API_KEY || ""
 const COLOR_LIST = [
   '#FFE4E1', '#708090', '#778899', '#696969', '#000099',
-  '#000066', '#87CEFA', '#B0C4DE', '#00008B', '#191970',
+  '#3333ff', '#003366', '#333399', '#00008B', '#191970',
   '#483D8B', '#4B0082', '#0000CD', '#7B68EE', '#4169E1',
   '#6495ED', '#008BBB', '#4682B4', '#1E90FF', '#00BFFF',
-  '#22FFFF', '#002200', '#ADD8E6', '#00FFFF', '#5F9EA0',
-  '#20B2AA', '#66CDAA', '#00CED1', '#48D1CC', '#550000',
-  '#B0E0E6', '#AFEEEE', '#6B8E23', '#556B2F', '#006400',
+  '#009999', '#006633', '#66cc00', '#3399ff', '#5F9EA0',
+  '#20B2AA', '#66CDAA', '#00CED1', '#48D1CC', '#99cc00',
+  '#00cc66', '#66cc99', '#6B8E23', '#556B2F', '#006400',
   '#228B22', '#2E8B57', '#3CB371', '#32CD32', '#9ACD32',
-  '#7FFFD4', '#00FA9A', '#00FF7F', '#7CFC00', '#7FFF00',
-  '#ADFF2F', '#90EE90', '#98FB98', '#8B008B', '#6A5ACD',
+  '#00cc66', '#669933', '#339966', '#33cc99', '#7FFF00',
+  '#6699cc', '#00cc66', '#339966', '#8B008B', '#6A5ACD',
   '#8A2BE2', '#9400D3', '#9932CC', '#BA55D3', '#9370DB',
   '#8FBC8F', '#8B0000', '#8B4513', '#A52A2A', '#B22222',
-  '#A0522D', '#CD5C5C', '#D2691E', '#BDB76B', '#DC143C',
-  '#FF1493', '#FF69B4', '#FF00FF', '#DA70D6', '#EE82EE',
-  '#DDA0DD', '#D8BfD8', '#BC8F8F', '#C71585', '#DB7093',
-  '#E9967A', '#F08080', '#FFA07A', '#FFB6C1', '#FFC0CB',
-  '#FF4500', '#FF6347', '#FF4F50', '#FA8072', '#FF8C00',
-  '#FFA500', '#F4A460', '#E6E6FA', '#B8860B', '#CD853F',
-  '#DAA520', '#D2B48C', '#DEB887', '#FFD700',
 ]
 
 
@@ -51,7 +44,7 @@ function CreateChartData(
 
   Object.entries(prefectures_list_data).forEach(([key, prefecture_value]) => {
     if (prefecture_value.checked) {
-      //Line のリスト生成　strokeの色を変えないと、同じ色のものが生成される　要変更
+      //Line のリスト生成
       return_Line_list.push(
         <Line
           type="monotone"
@@ -163,7 +156,6 @@ function PopulationChart() {
             left: 20,
             bottom: 40
           }}
-
         >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis

--- a/src/prefectures_list/PrefecturesList.scss
+++ b/src/prefectures_list/PrefecturesList.scss
@@ -55,7 +55,7 @@ ul.prefecture-list {
     }
 
     @include media(md) {
-        grid-template-columns: repeat(5, 1fr);
+        grid-template-columns: repeat(4, 1fr);
     }
 
     @include media(lg) {
@@ -64,6 +64,6 @@ ul.prefecture-list {
 
     @include media(xl) {
         max-width: 1400px;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(5, 1fr);
     }
 }

--- a/src/prefectures_list/PrefecturesList.scss
+++ b/src/prefectures_list/PrefecturesList.scss
@@ -55,7 +55,7 @@ ul.prefecture-list {
     }
 
     @include media(md) {
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(5, 1fr);
     }
 
     @include media(lg) {

--- a/src/prefectures_list/PrefecturesList.tsx
+++ b/src/prefectures_list/PrefecturesList.tsx
@@ -1,27 +1,45 @@
-import { stringify } from 'querystring';
-import React from 'react';
+import React, { useContext } from 'react';
+import { PrefecturesData } from '../types';
 import './PrefecturesList.scss';
+import {PrefecturesListDataContext} from '../App';
 
 function PrefecturesList() {
+  const {prefectures_list_data, setPrefecturesListData}=useContext(
+    PrefecturesListDataContext
+  )
+
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const index = Number(event.target.value)
+    var _prefectures_list_data = prefectures_list_data
+    _prefectures_list_data[index] = {
+      ..._prefectures_list_data[index],
+      checked:event.target.checked
+    }
+    
+    setPrefecturesListData(
+      _prefectures_list_data
+    )
+  }
+
   return (
     <section className="prefecture-list-container">
       <p>都道府県を選択</p>
       <ul className="prefecture-list">
         {(() => {
-          //適当なデータを挿入している　要変更
-          let checkbox_list = []
-
-          for (var i=0; i<47; i++){
-            checkbox_list.push(
-              <li key={i}>
+          const checkbox_list = prefectures_list_data.map((value,index) => {
+            return (
+              <li key={index}>
                 <input
-                 type="checkbox" 
-                 name={String(i)}
+                  type="checkbox"
+                  name={value.prefName}
+                  value={index}
+                  onChange={(event) => handleCheckboxChange(event)}
                 />
-                <label htmlFor={String(i)}>和歌山県</label>
+                <label htmlFor={value.prefName}>{value.prefName}</label>
               </li>
             )
-          }
+          })
+
           return checkbox_list
         })()}
       </ul>
@@ -30,3 +48,7 @@ function PrefecturesList() {
 }
 
 export default PrefecturesList;
+
+function PrefecturesListDataProvider(PrefecturesListDataProvider: any): { prefectures_list_data: any; setPrefecturesListData: any; } {
+  throw new Error('Function not implemented.');
+}

--- a/src/prefectures_list/PrefecturesList.tsx
+++ b/src/prefectures_list/PrefecturesList.tsx
@@ -1,24 +1,30 @@
 import React, { useContext } from 'react';
-import { PrefecturesData } from '../types';
+import { PrefectureData } from '../types';
 import './PrefecturesList.scss';
-import {PrefecturesListDataContext} from '../App';
+import { CheckboxCheckerContext, PrefecturesListDataContext } from '../App';
 
 function PrefecturesList() {
-  const {prefectures_list_data, setPrefecturesListData}=useContext(
+  const { prefectures_list_data, setPrefecturesListData } = useContext(
     PrefecturesListDataContext
+  )
+  const { setCheckboxChecker } = useContext(
+    CheckboxCheckerContext
   )
 
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const index = Number(event.target.value)
     var _prefectures_list_data = prefectures_list_data
+
     _prefectures_list_data[index] = {
       ..._prefectures_list_data[index],
-      checked:event.target.checked
+      checked: event.target.checked
     }
-    
+
     setPrefecturesListData(
       _prefectures_list_data
     )
+
+    setCheckboxChecker(_prefectures_list_data[index])
   }
 
   return (
@@ -26,7 +32,7 @@ function PrefecturesList() {
       <p>都道府県を選択</p>
       <ul className="prefecture-list">
         {(() => {
-          const checkbox_list = prefectures_list_data.map((value,index) => {
+          const checkbox_list = prefectures_list_data.map((value, index) => {
             return (
               <li key={index}>
                 <input
@@ -48,7 +54,3 @@ function PrefecturesList() {
 }
 
 export default PrefecturesList;
-
-function PrefecturesListDataProvider(PrefecturesListDataProvider: any): { prefectures_list_data: any; setPrefecturesListData: any; } {
-  throw new Error('Function not implemented.');
-}

--- a/src/prefectures_list/PrefecturesList.tsx
+++ b/src/prefectures_list/PrefecturesList.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { PrefectureData } from '../types';
 import './PrefecturesList.scss';
 import { CheckboxCheckerContext, PrefecturesListDataContext } from '../App';
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,10 +1,26 @@
+//PrefecturesList
 export type PrefecturesAPIData = {
-    prefCode:number,
-    prefName:string,
+    prefCode: number,
+    prefName: string,
 }
 
-export type PrefecturesData = {
-    prefCode:number,
-    prefName:string,
-    checked:boolean
+export type PrefectureData = {
+    prefCode: number,
+    prefName: string,
+    checked: boolean
+}
+
+
+//PopulationChart
+type PopulationData = {
+    year: number,
+    value: number
+}
+
+export type PrefecturesPopulationData = {
+    [key: string]: Array<PopulationData>
+}
+
+export type PopulationChartData = {
+    [key: number]:{[key: string]: number}
 }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,0 +1,10 @@
+export type PrefecturesAPIData = {
+    prefCode:number,
+    prefName:string,
+}
+
+export type PrefecturesData = {
+    prefCode:number,
+    prefName:string,
+    checked:boolean
+}


### PR DESCRIPTION
以下を実装

- APIから都道府県リストのデータを受け取る
- チェックボックスにチェックが入った県の人口データをAPIから取得
- 人口データとチェックボックスのcheckedの状況からチャート描写に必要なデータを生成、描写
-描写される都道府県の人口線グラフの色を個別に指定


